### PR TITLE
Fix download crash on multiple download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,5 @@ train.sh
 /wandb/
 /log/
 
-/graphbench_data/
 /graphbench_lib.egg-info/
 .DS_Store

--- a/graphbench/_helpers/_download.py
+++ b/graphbench/_helpers/_download.py
@@ -23,8 +23,11 @@ def download_and_unpack(source: SourceSpec, raw_dir: Union[str, Path], processed
     url = source.url
     filename = url.split("/")[-1]
     local_path = raw_dir / filename
-    #local_path = raw_dir / "data_small_vg_no_trans.pt.xz"
-    if not processed_dir.exists() or not any(Path(processed_dir).iterdir()):
+    # local_path = raw_dir / "data_small_vg_no_trans.pt.xz"
+    processed_dir = Path(processed_dir)
+    # Some dataset loaders pass a file path. Treat it as a directory check.
+    processed_dir_check = processed_dir.parent if processed_dir.suffix else processed_dir
+    if not processed_dir_check.exists() or not any(processed_dir_check.iterdir()):
         # the directory doesn’t exist or it exists but is empty (or the processed dir is missing/empty)
         _stream_download(url, local_path, logger)
         if local_path.suffixes[-2:] == [".pt",".xz"]:

--- a/graphbench/datasets/_algoreas.py
+++ b/graphbench/datasets/_algoreas.py
@@ -164,7 +164,10 @@ class AlgoReasDataset(InMemoryDataset):
             # Download and unpack into the raw directory, and then load the
             # first matching processed file using `_load_algoreas_graphs`.
             download_and_unpack(
-                source=self.source, raw_dir=self._raw_dir, logger=_logger, processed_dir=self.processed_path.parent
+                source=self.source,
+                raw_dir=self._raw_dir,
+                processed_dir=self.processed_path,
+                logger=_logger,
             )
 
             # The loader places the data into this InMemoryDataset instance

--- a/graphbench/datasets/_algoreas.py
+++ b/graphbench/datasets/_algoreas.py
@@ -164,7 +164,7 @@ class AlgoReasDataset(InMemoryDataset):
             # Download and unpack into the raw directory, and then load the
             # first matching processed file using `_load_algoreas_graphs`.
             download_and_unpack(
-                source=self.source, raw_dir=self._raw_dir, logger=_logger, processed_dir=self.processed_path
+                source=self.source, raw_dir=self._raw_dir, logger=_logger, processed_dir=self.processed_path.parent
             )
 
             # The loader places the data into this InMemoryDataset instance

--- a/graphbench/datasets/_bluesky.py
+++ b/graphbench/datasets/_bluesky.py
@@ -261,8 +261,8 @@ class BlueSkyDataset(InMemoryDataset):
 
     def _prepare(self) -> None:
         # (b) Download & unpack helpers
-        download_and_unpack(self.source, self._raw_dir, Path(self.processed_dir), logger=_logger)
-        download_and_unpack(self.source_features, self._raw_feature_dir, Path(self.processed_dir), logger=_logger)
+        download_and_unpack(self.source, self._raw_dir, self.processed_path.parent, logger=_logger)
+        download_and_unpack(self.source_features, self._raw_feature_dir, self.processed_path.parent, logger=_logger)
         # Pick default ts_train_end and gap per dataset type
        
         if self.name in {'bluesky_quotes', 'bluesky_replies', 'bluesky_reposts'}:

--- a/graphbench/datasets/_bluesky.py
+++ b/graphbench/datasets/_bluesky.py
@@ -261,8 +261,18 @@ class BlueSkyDataset(InMemoryDataset):
 
     def _prepare(self) -> None:
         # (b) Download & unpack helpers
-        download_and_unpack(self.source, self._raw_dir, self.processed_path.parent, logger=_logger)
-        download_and_unpack(self.source_features, self._raw_feature_dir, self.processed_path.parent, logger=_logger)
+        download_and_unpack(
+            source=self.source,
+            raw_dir=self._raw_dir,
+            processed_dir=self.processed_path,
+            logger=_logger,
+        )
+        download_and_unpack(
+            source=self.source_features,
+            raw_dir=self._raw_feature_dir,
+            processed_dir=self.processed_path,
+            logger=_logger,
+        )
         # Pick default ts_train_end and gap per dataset type
        
         if self.name in {'bluesky_quotes', 'bluesky_replies', 'bluesky_reposts'}:

--- a/graphbench/datasets/_chipdesign.py
+++ b/graphbench/datasets/_chipdesign.py
@@ -114,8 +114,8 @@ class ChipDesignDataset(InMemoryDataset):
         download_and_unpack(
             source=self.source,
             raw_dir=self._raw_dir,
+            processed_dir=self.processed_path,
             logger=_logger,
-            processed_dir=self.processed_path.parent,
         )
 
         # Load and convert the raw files to PyG Data objects

--- a/graphbench/datasets/_chipdesign.py
+++ b/graphbench/datasets/_chipdesign.py
@@ -111,7 +111,12 @@ class ChipDesignDataset(InMemoryDataset):
 
         # Download/unpack the archive into `self._raw_dir` and provide a
         # `processed_dir` hint for helpers that may extract processed artifacts.
-        download_and_unpack(source=self.source, raw_dir=self._raw_dir, logger=_logger, processed_dir=self.processed_path)
+        download_and_unpack(
+            source=self.source,
+            raw_dir=self._raw_dir,
+            logger=_logger,
+            processed_dir=self.processed_path.parent,
+        )
 
         # Load and convert the raw files to PyG Data objects
         data_list = self._load_chipdesign_graphs()

--- a/graphbench/datasets/_combinatorial_optimization.py
+++ b/graphbench/datasets/_combinatorial_optimization.py
@@ -177,7 +177,12 @@ class CODataset(InMemoryDataset):
             self.save(data, self.processed_path)
             _logger.info(f"Saved processed dataset -> {self.processed_path}")
         else:
-            download_and_unpack(source=self.source, raw_dir=self.raw_dir, processed_dir=Path(self.processed_dir), logger=_logger)
+            download_and_unpack(
+                source=self.source, 
+                raw_dir=self.raw_dir, 
+                processed_dir=self.processed_path.parent, 
+                logger=_logger
+                )
 
             filepaths = self._find_matching_files(task=self.dataset_name, directory=self.raw_dir)
             self.load(filepaths[0])

--- a/graphbench/datasets/_combinatorial_optimization.py
+++ b/graphbench/datasets/_combinatorial_optimization.py
@@ -178,11 +178,11 @@ class CODataset(InMemoryDataset):
             _logger.info(f"Saved processed dataset -> {self.processed_path}")
         else:
             download_and_unpack(
-                source=self.source, 
-                raw_dir=self.raw_dir, 
-                processed_dir=self.processed_path.parent, 
-                logger=_logger
-                )
+                source=self.source,
+                raw_dir=self.raw_dir,
+                processed_dir=self.processed_path,
+                logger=_logger,
+            )
 
             filepaths = self._find_matching_files(task=self.dataset_name, directory=self.raw_dir)
             self.load(filepaths[0])

--- a/graphbench/datasets/_electroniccircuits.py
+++ b/graphbench/datasets/_electroniccircuits.py
@@ -130,7 +130,12 @@ class ECDataset(InMemoryDataset):
         if self.generate:
             self._generate(None, None)
         else:
-            download_and_unpack(source=self.source, raw_dir=self._raw_dir, processed_dir=self.processed_path, logger=_logger)
+            download_and_unpack(
+                source=self.source,
+                raw_dir=self._raw_dir,
+                processed_dir=self.processed_path.parent,
+                logger=_logger,
+            )
 
             train_json = self.load_json(os.path.join(self._raw_dir, f"dataset_{self.component_size}_train.json"))
             valid_json = self.load_json(os.path.join(self._raw_dir, f"dataset_{self.component_size}_valid.json"))

--- a/graphbench/datasets/_electroniccircuits.py
+++ b/graphbench/datasets/_electroniccircuits.py
@@ -133,7 +133,7 @@ class ECDataset(InMemoryDataset):
             download_and_unpack(
                 source=self.source,
                 raw_dir=self._raw_dir,
-                processed_dir=self.processed_path.parent,
+                processed_dir=self.processed_path,
                 logger=_logger,
             )
 

--- a/graphbench/datasets/_electroniccircuits.py
+++ b/graphbench/datasets/_electroniccircuits.py
@@ -16,7 +16,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 
 import numpy as np
 import torch
-import tqdm
+from tqdm import tqdm
 from torch_geometric.data import Data, InMemoryDataset
 
 from graphbench._helpers import download_and_unpack, SourceSpec, get_logger

--- a/graphbench/datasets/_sat.py
+++ b/graphbench/datasets/_sat.py
@@ -122,7 +122,12 @@ class SATDataset(InMemoryDataset):
         csv_dir = Path(root) / self.SOURCE_CSV.raw_folder
         if not csv_dir.exists():
             print(f"Downloading supplementary CSV files to {csv_dir}...")
-            download_and_unpack(source=self.SOURCE_CSV, raw_dir=csv_dir, processed_dir=csv_dir / "processed", logger=_logger)
+            download_and_unpack(
+                source=self.SOURCE_CSV,
+                raw_dir=csv_dir,
+                processed_dir=csv_dir / "processed",
+                logger=_logger,
+            )
         self.solver = solver
         self.instances_csv = pd.read_csv(Path(root) /"sat_csv"/ "instances_new.csv")
         #self.dataset_name = self.name_temp.lower().split(" ")[0]

--- a/graphbench/datasets/_sat.py
+++ b/graphbench/datasets/_sat.py
@@ -558,7 +558,12 @@ class SATDataset(InMemoryDataset):
             #torch.save((data, slices), self.processed_path)
 
         else:
-            download_and_unpack(source=self.source, raw_dir=self._raw_dir, processed_dir=self.processed_path, logger=_logger)
+            download_and_unpack(
+                source=self.source,
+                raw_dir=self._raw_dir,
+                processed_dir=self.processed_path,
+                logger=_logger,
+            )
 
             loader = self._load_sat_graphs
             loader_kwargs = {}

--- a/graphbench/datasets/_weatherforecasting.py
+++ b/graphbench/datasets/_weatherforecasting.py
@@ -108,7 +108,12 @@ class WeatherforecastingDataset(InMemoryDataset):
             #currently not implemented
             data_list = self._generate()
         else:
-            download_and_unpack(source=self.source, raw_dir=self._raw_dir, logger=_logger, processed_dir=self.processed_path)
+            download_and_unpack(
+                source=self.source,
+                raw_dir=self._raw_dir,
+                logger=_logger,
+                processed_dir=self.processed_path.parent,
+            )
             loader = self._load_weather_graphs
             loader_kwargs = {}
             data_list = loader(**loader_kwargs)

--- a/graphbench/datasets/_weatherforecasting.py
+++ b/graphbench/datasets/_weatherforecasting.py
@@ -111,8 +111,8 @@ class WeatherforecastingDataset(InMemoryDataset):
             download_and_unpack(
                 source=self.source,
                 raw_dir=self._raw_dir,
+                processed_dir=self.processed_path,
                 logger=_logger,
-                processed_dir=self.processed_path.parent,
             )
             loader = self._load_weather_graphs
             loader_kwargs = {}


### PR DESCRIPTION
* Before: For some datasets, starting from the second download, the script for download_and_unpack would try to call .iterdir() for a path to a file, which would result in an error.
* Fix: If path points to a file, call .iterdir() for the parent directory instead.