### PR TITLE
Fix the bug with cleanup_raw

### DIFF
--- a/graphbench/_helpers/_download.py
+++ b/graphbench/_helpers/_download.py
@@ -17,33 +17,43 @@ class SourceSpec:
     raw_folder: str  # folder name inside tmp/ where data will appear
 
 
-def download_and_unpack(source: SourceSpec, raw_dir: Union[str, Path], processed_dir: Union[str, Path], logger) -> None:
+class IncompleteDownloadError(IOError):
+    """Raised when a response body is shorter than its declared Content-Length."""
+
+
+def _is_unpacked(raw_dir: Path, archive_name: str) -> bool:
+    """True if `raw_dir` already holds unpacked data.
+    """
+    if not raw_dir.exists():
+        return False
+    return any(p.name != archive_name for p in raw_dir.iterdir())
+
+
+def download_and_unpack(source: SourceSpec, raw_dir: Union[str, Path], logger) -> None:
     raw_dir = Path(raw_dir)
-    raw_dir.mkdir(parents=True, exist_ok=True)
     url = source.url
     filename = url.split("/")[-1]
     local_path = raw_dir / filename
-    # local_path = raw_dir / "data_small_vg_no_trans.pt.xz"
-    processed_dir = Path(processed_dir)
-    # Some dataset loaders pass a file path. Treat it as a directory check.
-    processed_dir_check = processed_dir.parent if processed_dir.suffix else processed_dir
-    if not processed_dir_check.exists() or not any(processed_dir_check.iterdir()):
-        # the directory doesn’t exist or it exists but is empty (or the processed dir is missing/empty)
-        _stream_download(url, local_path, logger)
-        if local_path.suffixes[-2:] == [".pt",".xz"]:
-            _unpack_xz(local_path, dest_dir=raw_dir)
-        elif local_path.suffixes[-2:] == [".tar", ".gz"]:
-            _safe_extract_tar(local_path, raw_dir)
-            _gunzip_in_tree(raw_dir)  # also handles nested .gz
-        elif local_path.suffix == ".gz":
-            _gunzip_file(local_path)
-        elif local_path.suffix == ".zip":
-            _unpack_zip(local_path, dest_dir=raw_dir)
-        else:
-            logger.warning(f"Unknown archive type for {local_path}; leaving as-is.")
-        print(f"Downloaded and unpacked data to {raw_dir}")
-    else:
+
+    # Decide against the raw dir, not the processed dir
+    if _is_unpacked(raw_dir, filename):
         logger.info(f"Found existing download dir: {raw_dir}")
+        return
+
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    _stream_download(url, local_path, logger)
+    if local_path.suffixes[-2:] == [".pt",".xz"]:
+        _unpack_xz(local_path, dest_dir=raw_dir)
+    elif local_path.suffixes[-2:] == [".tar", ".gz"]:
+        _safe_extract_tar(local_path, raw_dir)
+        _gunzip_in_tree(raw_dir)  # also handles nested .gz
+    elif local_path.suffix == ".gz":
+        _gunzip_file(local_path)
+    elif local_path.suffix == ".zip":
+        _unpack_zip(local_path, dest_dir=raw_dir)
+    else:
+        logger.warning(f"Unknown archive type for {local_path}; leaving as-is.")
+    print(f"Downloaded and unpacked data to {raw_dir}")
 
 def _stream_download(
     url: str,
@@ -75,12 +85,26 @@ def _stream_download(
                     continue
 
                 r.raise_for_status()
+                expected = _expected_length(r)
+                written = 0
                 with open(dest, "wb") as f:
                     for chunk in r.iter_content(chunk_size=chunk_size):
                         if chunk:
                             f.write(chunk)
+                            written += len(chunk)
+
+                # A server that closes the connection early ends iter_content
+                # without raising, which would silently leave a truncated
+                # archive on disk and fail much later.
+                if expected is not None and written != expected:
+                    raise IncompleteDownloadError(
+                        f"Truncated download: got {written} of {expected} bytes from {url}"
+                    )
                 return
-        except requests.RequestException as exc:  # includes timeouts and connection errors
+        except (requests.RequestException, IncompleteDownloadError) as exc:
+            # Don't leave a partial file behind: it is useless and would be
+            # mistaken for a real archive by anything inspecting the raw dir.
+            dest.unlink(missing_ok=True)
             if attempt == max_retries:
                 raise
             logger.warning(
@@ -91,6 +115,13 @@ def _stream_download(
                 cooldown_seconds,
             )
             time.sleep(cooldown_seconds)
+
+
+def _expected_length(response) -> Optional[int]:
+    if response.headers.get("Content-Encoding"):
+        return None
+    content_length = response.headers.get("Content-Length")
+    return int(content_length) if content_length is not None else None
 
 def _safe_extract_tar(path: Path, dest_dir: Path) -> None:
     """Extract tar.gz safely (prevents path traversal)."""

--- a/graphbench/_loader/_loader.py
+++ b/graphbench/_loader/_loader.py
@@ -82,6 +82,10 @@ class Loader():
         self.sat_solver = sat_solver
         self.use_satzilla_features = use_satzilla_features
         self.generate = False
+        # Datasets built for the dataset currently being assembled. Splits of one
+        # dataset share a raw dir, so raw cleanup is deferred until all of them
+        # are built (see `_loader`).
+        self._built_datasets: List[InMemoryDataset] = []
 
         if self.generate_fallback:
             self.generate = True
@@ -191,7 +195,31 @@ class Loader():
         return self.data_list
         
     def _loader(self, dataset_name: str) -> TrainValTestSet:
-        return self._registry.build(dataset_name)
+        self._built_datasets = []
+        try:
+            datasets = self._registry.build(dataset_name)
+        finally:
+            # Every split of a dataset reads from the same raw dir, so cleaning
+            # it up per split would delete the archive the next split still
+            # needs, forcing a fresh download each time. Clean up once, after
+            # the whole split set is built.
+            self._cleanup_raw_dirs()
+        return datasets
+
+    def _track(self, dataset: InMemoryDataset) -> InMemoryDataset:
+        """Register a dataset whose raw dir should be cleaned up after the build."""
+        self._built_datasets.append(dataset)
+        return dataset
+
+    def _cleanup_raw_dirs(self) -> None:
+        datasets, self._built_datasets = self._built_datasets, []
+        cleaned: set[str] = set()
+        for dataset in datasets:
+            raw_dir = getattr(dataset, "_raw_dir", None)
+            if raw_dir is None or str(raw_dir) in cleaned:
+                continue
+            cleaned.add(str(raw_dir))
+            dataset._cleanup()
 
     def _make_algoreas_dataset(
         self,
@@ -201,13 +229,16 @@ class Loader():
     ) -> InMemoryDataset:
         from graphbench.datasets import AlgoReasDataset
 
-        return AlgoReasDataset(
-            root=self.root,
-            name=name_override or dataset_name,
-            pre_filter=self.pre_filter,
-            pre_transform=self.pre_transform,
-            transform=self.transform,
-            split=split,
+        return self._track(
+            AlgoReasDataset(
+                root=self.root,
+                name=name_override or dataset_name,
+                pre_filter=self.pre_filter,
+                pre_transform=self.pre_transform,
+                transform=self.transform,
+                split=split,
+                cleanup_raw=False,
+            )
         )
 
     def _make_bluesky_dataset(
@@ -218,14 +249,17 @@ class Loader():
     ) -> InMemoryDataset:
         from graphbench.datasets import BlueSkyDataset
 
-        return BlueSkyDataset(
-            root=self.root,
-            name=name_override or dataset_name,
-            pre_filter=self.pre_filter,
-            pre_transform=self.pre_transform,
-            transform=self.transform,
-            split=split,
-            load_preprocessed=True,
+        return self._track(
+            BlueSkyDataset(
+                root=self.root,
+                name=name_override or dataset_name,
+                pre_filter=self.pre_filter,
+                pre_transform=self.pre_transform,
+                transform=self.transform,
+                split=split,
+                load_preprocessed=True,
+                cleanup_raw=False,
+            )
         )
 
     def _make_chipdesign_dataset(
@@ -236,13 +270,16 @@ class Loader():
     ) -> InMemoryDataset:
         from graphbench.datasets import ChipDesignDataset
 
-        return ChipDesignDataset(
-            root=self.root,
-            name=name_override or dataset_name,
-            pre_filter=self.pre_filter,
-            pre_transform=self.pre_transform,
-            transform=self.transform,
-            split=split,
+        return self._track(
+            ChipDesignDataset(
+                root=self.root,
+                name=name_override or dataset_name,
+                pre_filter=self.pre_filter,
+                pre_transform=self.pre_transform,
+                transform=self.transform,
+                split=split,
+                cleanup_raw=False,
+            )
         )
 
     def _make_weather_dataset(
@@ -277,14 +314,17 @@ class Loader():
     ) -> InMemoryDataset:
         from graphbench.datasets import CODataset
 
-        return CODataset(
-            root=self.root,
-            name=name_override or dataset_name,
-            pre_filter=self.pre_filter,
-            pre_transform=self.pre_transform,
-            transform=self.transform,
-            split=split,
-            generate=self.generate,
+        return self._track(
+            CODataset(
+                root=self.root,
+                name=name_override or dataset_name,
+                pre_filter=self.pre_filter,
+                pre_transform=self.pre_transform,
+                transform=self.transform,
+                split=split,
+                generate=self.generate,
+                cleanup_raw=False,
+            )
         )
 
     def _make_sat_dataset(
@@ -295,15 +335,18 @@ class Loader():
     ) -> InMemoryDataset:
         from graphbench.datasets import SATDataset
 
-        return SATDataset(
-            root=self.root,
-            name=name_override or dataset_name,
-            pre_filter=self.pre_filter,
-            pre_transform=self.pre_transform,
-            transform=self.transform,
-            split=split,
-            solver=self.sat_solver,
-            use_satzilla_features=self.use_satzilla_features,
+        return self._track(
+            SATDataset(
+                root=self.root,
+                name=name_override or dataset_name,
+                pre_filter=self.pre_filter,
+                pre_transform=self.pre_transform,
+                transform=self.transform,
+                split=split,
+                solver=self.sat_solver,
+                use_satzilla_features=self.use_satzilla_features,
+                cleanup_raw=False,
+            )
         )
 
     def _make_ec_dataset(
@@ -314,13 +357,16 @@ class Loader():
     ) -> InMemoryDataset:
         from graphbench.datasets import ECDataset
 
-        return ECDataset(
-            root=self.root,
-            name=name_override or dataset_name,
-            pre_filter=self.pre_filter,
-            pre_transform=self.pre_transform,
-            transform=self.transform,
-            split=split,
+        return self._track(
+            ECDataset(
+                root=self.root,
+                name=name_override or dataset_name,
+                pre_filter=self.pre_filter,
+                pre_transform=self.pre_transform,
+                transform=self.transform,
+                split=split,
+                cleanup_raw=False,
+            )
         )
 
 

--- a/graphbench/_loader/_loader.py
+++ b/graphbench/_loader/_loader.py
@@ -225,7 +225,6 @@ class Loader():
             pre_transform=self.pre_transform,
             transform=self.transform,
             split=split,
-            cleanup_raw=False,
             load_preprocessed=True,
         )
 

--- a/graphbench/datasets/_algoreas.py
+++ b/graphbench/datasets/_algoreas.py
@@ -173,7 +173,7 @@ class AlgoReasDataset(GraphDataset):
         transform: Optional[Callable[[Data], Data]] = None,
         pre_transform: Optional[Callable[[Data], Data]] = None,
         pre_filter: Optional[Callable[[Data], bool]] = None,
-        cleanup_raw: bool = True,
+        cleanup_raw: bool = False,
     ):
         """
         Args:
@@ -272,7 +272,6 @@ class AlgoReasDataset(GraphDataset):
         download_and_unpack(
             source=self.source,
             raw_dir=self._raw_dir,
-            processed_dir=self.processed_path,
             logger=_logger,
         )
 

--- a/graphbench/datasets/_algoreas.py
+++ b/graphbench/datasets/_algoreas.py
@@ -173,7 +173,7 @@ class AlgoReasDataset(GraphDataset):
         transform: Optional[Callable[[Data], Data]] = None,
         pre_transform: Optional[Callable[[Data], Data]] = None,
         pre_filter: Optional[Callable[[Data], bool]] = None,
-        cleanup_raw: bool = False,
+        cleanup_raw: bool = True,
     ):
         """
         Args:

--- a/graphbench/datasets/_base.py
+++ b/graphbench/datasets/_base.py
@@ -1,3 +1,4 @@
+import shutil
 from pathlib import Path
 from abc import ABC, abstractmethod
 
@@ -16,17 +17,10 @@ class GraphDataset(InMemoryDataset, ABC):
         if logger is not None:
             logger.info(f"Cleaning up: {raw_dir}")
 
-        # remove only the dataset-specific temp folder
-        for path in sorted(raw_dir.rglob("*"), reverse=True):
-            try:
-                path.unlink()
-            except (IsADirectoryError, PermissionError):
-                pass
-
-        try:
-            raw_dir.rmdir()
-        except OSError:
-            pass
+        if raw_dir.is_dir():
+            shutil.rmtree(raw_dir, ignore_errors=False)
+        else:
+            raw_dir.unlink()
 
     @abstractmethod
     def _prepare(self) -> None:
@@ -79,6 +73,8 @@ class GraphDataset(InMemoryDataset, ABC):
                 if logger is not None:
                     logger.info(f"Loading cached processed data: {processed_path}")
                 self.load(resolved_load_path)
+                if cleanup_raw:
+                    self._cleanup()
                 return
             except Exception as e:
                 if logger is not None:

--- a/graphbench/datasets/_bluesky.py
+++ b/graphbench/datasets/_bluesky.py
@@ -284,7 +284,7 @@ class BlueSkyDataset(GraphDataset):
         transform: Optional[Callable[[Data], Data]] = None,
         pre_transform: Optional[Callable[[Data], Data]] = None,
         pre_filter: Optional[Callable[[Data], bool]] = None,
-        cleanup_raw: bool = True,
+        cleanup_raw: bool = False,
         # TODO: This should be removed in the future -- the user will download these files
         load_preprocessed = True,
         feature_file_name: Union[str, Path] = _FEATURE_PT_PATH,
@@ -344,13 +344,11 @@ class BlueSkyDataset(GraphDataset):
         download_and_unpack(
             source=self.source,
             raw_dir=self._raw_dir,
-            processed_dir=self.processed_path,
             logger=_logger,
         )
         download_and_unpack(
             source=self.source_features,
             raw_dir=self._raw_feature_dir,
-            processed_dir=self.processed_path,
             logger=_logger,
         )
 

--- a/graphbench/datasets/_bluesky.py
+++ b/graphbench/datasets/_bluesky.py
@@ -284,7 +284,7 @@ class BlueSkyDataset(GraphDataset):
         transform: Optional[Callable[[Data], Data]] = None,
         pre_transform: Optional[Callable[[Data], Data]] = None,
         pre_filter: Optional[Callable[[Data], bool]] = None,
-        cleanup_raw: bool = False,
+        cleanup_raw: bool = True,
         # TODO: This should be removed in the future -- the user will download these files
         load_preprocessed = True,
         feature_file_name: Union[str, Path] = _FEATURE_PT_PATH,

--- a/graphbench/datasets/_chipdesign.py
+++ b/graphbench/datasets/_chipdesign.py
@@ -104,7 +104,7 @@ class ChipDesignDataset(GraphDataset):
         transform: Optional[Callable[[Data], Data]] = None,
         pre_transform: Optional[Callable[[Data], Data]] = None,
         pre_filter: Optional[Callable[[Data], bool]] = None,
-        cleanup_raw: bool = False,  # TODO Disabling this for now since it leads to errors on my machine
+        cleanup_raw: bool = True,  # TODO Disabling this for now since it leads to errors on my machine
     ):
         """
         Args:

--- a/graphbench/datasets/_chipdesign.py
+++ b/graphbench/datasets/_chipdesign.py
@@ -104,7 +104,7 @@ class ChipDesignDataset(GraphDataset):
         transform: Optional[Callable[[Data], Data]] = None,
         pre_transform: Optional[Callable[[Data], Data]] = None,
         pre_filter: Optional[Callable[[Data], bool]] = None,
-        cleanup_raw: bool = True,  # TODO Disabling this for now since it leads to errors on my machine
+        cleanup_raw: bool = False,  # TODO Disabling this for now since it leads to errors on my machine
     ):
         """
         Args:
@@ -157,7 +157,6 @@ class ChipDesignDataset(GraphDataset):
         download_and_unpack(
             source=self.source,
             raw_dir=self._raw_dir,
-            processed_dir=self.processed_path,
             logger=_logger,
         )
 

--- a/graphbench/datasets/_combinatorial_optimization.py
+++ b/graphbench/datasets/_combinatorial_optimization.py
@@ -186,7 +186,7 @@ class CODataset(GraphDataset):
         pre_filter: Optional[Callable[[Data], bool]] = None,
         generate: Optional[bool] = False,
         num_samples: Optional[int] = None,
-        cleanup_raw: bool = True,
+        cleanup_raw: bool = False,
     ):
         """
         Args:
@@ -294,7 +294,6 @@ class CODataset(GraphDataset):
         download_and_unpack(
             source=self.source,
             raw_dir=self._raw_dir,
-            processed_dir=self.processed_path,
             logger=_logger,
         )
 
@@ -323,10 +322,12 @@ class CODataset(GraphDataset):
             if path.is_file()
         )
         return matches
-    
-    def process(self):
-        self._prepare()
-        
+
+    # NOTE: deliberately no `process()` override. PyG only runs its `_process()`
+    # hook for classes that define one, and it does so from `__init__` *before*
+    # `_load_cached_or_prepare` can check the processed cache -- which made every
+    # load re-download the raw archive. `_prepare()` is already called on a cache
+    # miss, so let PyG skip `_process()` as it does for the other datasets.
 
     @property
     def raw_file_names(self) -> list[str]:

--- a/graphbench/datasets/_combinatorial_optimization.py
+++ b/graphbench/datasets/_combinatorial_optimization.py
@@ -186,7 +186,7 @@ class CODataset(GraphDataset):
         pre_filter: Optional[Callable[[Data], bool]] = None,
         generate: Optional[bool] = False,
         num_samples: Optional[int] = None,
-        cleanup_raw: bool = False,
+        cleanup_raw: bool = True,
     ):
         """
         Args:
@@ -303,6 +303,8 @@ class CODataset(GraphDataset):
             return self._generate()
 
         filepaths = self._find_matching_files(task=self.dataset_name, directory=self._raw_dir)
+        if not filepaths:
+            raise FileNotFoundError(f"No matching raw dataset files found in {self._raw_dir}")
         self.load(filepaths[0])
 
         return [self.get(i) for i in range(len(self))]
@@ -311,7 +313,16 @@ class CODataset(GraphDataset):
         """
         Returns a list of filenames matching the convention in the directory.
         """
-        return [str(self.processed_path)]
+        directory = Path(directory)
+        if not directory.exists():
+            return []
+
+        matches = sorted(
+            str(path)
+            for path in directory.rglob("data.pt")
+            if path.is_file()
+        )
+        return matches
     
     def process(self):
         self._prepare()

--- a/graphbench/datasets/_electroniccircuits.py
+++ b/graphbench/datasets/_electroniccircuits.py
@@ -142,7 +142,7 @@ class ECDataset(GraphDataset):
         transform: Optional[Callable[[Data], Data]] = None,
         pre_transform: Optional[Callable[[Data], Data]] = None,
         pre_filter: Optional[Callable[[Data], bool]] = None,
-        cleanup_raw: bool = True,
+        cleanup_raw: bool = False,
         target_vout : Optional[float] = None,
         vout_norm_method : Optional[Literal["min-max", "reward", "IQR", "z-score"]] = "min-max",
     ):
@@ -228,7 +228,6 @@ class ECDataset(GraphDataset):
         download_and_unpack(
             source=self.source,
             raw_dir=self._raw_dir,
-            processed_dir=self.processed_path,
             logger=_logger,
         )
 

--- a/graphbench/datasets/_electroniccircuits.py
+++ b/graphbench/datasets/_electroniccircuits.py
@@ -142,7 +142,7 @@ class ECDataset(GraphDataset):
         transform: Optional[Callable[[Data], Data]] = None,
         pre_transform: Optional[Callable[[Data], Data]] = None,
         pre_filter: Optional[Callable[[Data], bool]] = None,
-        cleanup_raw: bool = False,
+        cleanup_raw: bool = True,
         target_vout : Optional[float] = None,
         vout_norm_method : Optional[Literal["min-max", "reward", "IQR", "z-score"]] = "min-max",
     ):

--- a/graphbench/datasets/_sat.py
+++ b/graphbench/datasets/_sat.py
@@ -157,7 +157,7 @@ class SATDataset(GraphDataset):
         pre_transform: Optional[Callable[[Data], Data]] = None,
         pre_filter: Optional[Callable[[Data], bool]] = None,
         use_satzilla_features: bool = False,
-        cleanup_raw: bool = False,
+        cleanup_raw: bool = True,
         solver: Optional[str] = None,
     ):
         """

--- a/graphbench/datasets/_sat.py
+++ b/graphbench/datasets/_sat.py
@@ -157,7 +157,7 @@ class SATDataset(GraphDataset):
         pre_transform: Optional[Callable[[Data], Data]] = None,
         pre_filter: Optional[Callable[[Data], bool]] = None,
         use_satzilla_features: bool = False,
-        cleanup_raw: bool = True,
+        cleanup_raw: bool = False,
         solver: Optional[str] = None,
     ):
         """
@@ -213,7 +213,6 @@ class SATDataset(GraphDataset):
             download_and_unpack(
                 source=self.SOURCE_CSV,
                 raw_dir=csv_dir,
-                processed_dir=csv_dir / "processed",
                 logger=_logger,
             )
         self.solver = solver
@@ -632,7 +631,6 @@ class SATDataset(GraphDataset):
         download_and_unpack(
             source=self.source,
             raw_dir=self._raw_dir,
-            processed_dir=self.processed_path,
             logger=_logger,
         )
 


### PR DESCRIPTION
# Changes:
- In `_base.py`: uses `rmtree` instead of `unlink`, which allows for deleting directories cleanly
- In `_combinatorial_optimization.py`: now loads the actual unpacked raw `data.pt` from the archive layout instead of trying to read the processed cache path before it exists.
- `cleanup_raw` now defaults to `True` for every dataset (except for Weather Forecasting)

# (Update) Bug:
Loading a multi-split dataset could re-download the raw archive multiple times per `Loader.load()`, and in some cases even fail with a `FileNotFoundError`

**The root cause:** a dataset is built as three split instances (train/val/test) that **share a single raw directory**. With `cleanup_raw=True` (the default), each split deleted that shared raw dir immediately after processing, so the train split removed the archive the val/test splits still needed, forcing a re-download per split, or a hard `FileNotFoundError` when a later split found the raw dir gone. Moreover, `download_and_unpack` decided whether to download by inspecting the **processed** dir, but sibling splits each write their own processed file, so any one split's file made the guard wrongly conclude already downloaded.

# Fix:
**1. Download once per dataset, not once per split** (`_loader.py`)
- The `Loader` now tracks the dataset instances it builds and defers raw cleanup until the whole split set is assembled, cleaning each distinct raw dir exactly once (in a `finally`, so partial builds still clean up).
- **All dataset factories pass `cleanup_raw=False`, cleanup is centralized in the loader.**

**2. Guard the download on the raw dir, rather than the processed dir** (`_download.py`)
- Replaced the processed-dir check with `_is_unpacked(raw_dir, archive_name)`, which asks whether the raw dir already holds unpacked data. A dir containing only the archive is treated as a partial download and redone.
- Removed the now-unused `processed_dir` parameter from `download_and_unpack` and all call sites.

**3. Verify download integrity** (`_download.py`)
- `_stream_download` now compares bytes written against `Content-Length` and raises `IncompleteDownloadError` on a short read, so truncated downloads are retried instead of silently corrupting the archive. Partial files are removed before retry.
- The check is skipped when it can't be applied safely.